### PR TITLE
Recommend using TCP with TLS in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Then add the appender to your `logback.xml`.
       <port>514</port>
       <!-- program name to log as -->
       <ident>java-app</ident>
+      <!-- max log message length in bytes -->
+      <maxMessageLength>128000</maxMessageLength>
     </syslogConfig>
   </appender>
 
@@ -64,6 +66,8 @@ Then add the appender to your `logback.xml`.
       <port>514</port>
       <!-- program name to log as -->
       <ident>java-app</ident>
+      <!-- max log message length in bytes -->
+      <maxMessageLength>128000</maxMessageLength>
     </syslogConfig>
   </appender>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `pom.xml`:
 Then add the appender to your `logback.xml`.
 
 
-#### Logging via TCP with TLS
+#### Logging via TCP with TLS (recommended)
 
 ``` xml
   <appender name="SYSLOG-TLS" class="com.papertrailapp.logback.Syslog4jAppender">

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Add this to your `pom.xml`:
 Then add the appender to your `logback.xml`.
 
 
-#### Logging via UDP
+#### Logging via TCP with TLS
 
 ``` xml
-  <appender name="SYSLOG-UDP" class="com.papertrailapp.logback.Syslog4jAppender">
+  <appender name="SYSLOG-TLS" class="com.papertrailapp.logback.Syslog4jAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%-5level %logger{35}: %m%n%xEx</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslogConfig">
+    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
       <!-- remote system to log to -->
       <host>localhost</host>
       <!-- remote port to log to -->
@@ -45,7 +45,7 @@ Then add the appender to your `logback.xml`.
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="SYSLOG-UDP" />
+    <appender-ref ref="SYSLOG-TLS" />
   </root>
 ```
 
@@ -72,15 +72,15 @@ Then add the appender to your `logback.xml`.
   </root>
 ```
 
-#### Logging via TCP with TLS
+#### Logging via UDP
 
 ``` xml
-  <appender name="SYSLOG-TLS" class="com.papertrailapp.logback.Syslog4jAppender">
+  <appender name="SYSLOG-UDP" class="com.papertrailapp.logback.Syslog4jAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%-5level %logger{35}: %m%n%xEx</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
+    <syslogConfig class="org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslogConfig">
       <!-- remote system to log to -->
       <host>localhost</host>
       <!-- remote port to log to -->
@@ -91,7 +91,7 @@ Then add the appender to your `logback.xml`.
   </appender>
 
   <root level="DEBUG">
-    <appender-ref ref="SYSLOG-TLS" />
+    <appender-ref ref="SYSLOG-UDP" />
   </root>
 ```
 


### PR DESCRIPTION
I had the same issues as described in #1 but I solved them by switching from UDP to TCP with TLS and specifying an explicit `maxMessageLength` parameter.

This readme is [referenced](http://help.papertrailapp.com/kb/configuration/java-logback-logging/) pretty much as an official guide for using logback with papertrail.
1. The first problem was that there were 3 options for configuring the Syslog4jAppender but the first two have issues and I only managed to get the desired result with the third one. So I moved it to the first place and marked it as recommended.
2. The second issue was the one described in #1 which I managed to solve by adding the `maxMessageLength` with value 128000 to the `SSLTCPNetSyslogConfig`. 128000 is an arbitrary large number that works for me. It has no specific meaning.