### PR TITLE
Replaced the old and unmaintained syslog4j dependency with the newer fork from graylog2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## logback-syslog4j
 
-A [Logback][] appender that leverages [syslog4j][] to send log messages to
+A [Logback][] appender that leverages [syslog4j-graylog2][] to send log messages to
 remote systems via syslog.
 
 ### Why?
@@ -26,7 +26,7 @@ Add this to your `pom.xml`:
 Then add the appender to your `logback.xml`.
 
 If not using Maven, download [logback-syslog4j-1.0.0.jar][] and the latest
-[syslog4j][] JAR.  Place these files in the classpath, in addition to Logback
+[syslog4j-graylog2][] JAR.  Place these files in the classpath, in addition to Logback
 itself.
 
 #### Logging via TCP with TLS (recommended)
@@ -37,7 +37,7 @@ itself.
       <pattern>%-5level %logger{35}: %m%n%xEx</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
       <!-- remote system to log to -->
       <host>localhost</host>
       <!-- remote port to log to -->
@@ -62,7 +62,7 @@ itself.
       <pattern>%-5level %logger{35}: %m%n%xEx</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
       <!-- remote system to log to -->
       <host>localhost</host>
       <!-- remote port to log to -->
@@ -87,7 +87,7 @@ itself.
       <pattern>%-5level %logger{35}: %m%n%xEx</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.udp.UDPNetSyslogConfig">
       <!-- remote system to log to -->
       <host>localhost</host>
       <!-- remote port to log to -->
@@ -104,6 +104,6 @@ itself.
 
 
 [Logback]: http://logback.qos.ch/
-[syslog4j]: http://syslog4j.org/
+[syslog4j-graylog2]: https://github.com/graylog-labs/syslog4j-graylog2
 [logback-syslog-appender]: http://logback.qos.ch/manual/appenders.html#SyslogAppender
 [logback-syslog4j-1.0.0.jar]: http://search.maven.org/remotecontent?filepath=com/papertrailapp/logback-syslog4j/1.0.0/logback-syslog4j-1.0.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <logback.version>1.1.2</logback.version>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -55,9 +57,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.syslog4j</groupId>
+      <groupId>org.graylog2</groupId>
       <artifactId>syslog4j</artifactId>
-      <version>0.9.30</version>
+      <version>0.9.60</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/papertrailapp/logback/Syslog4jAppender.java
+++ b/src/main/java/com/papertrailapp/logback/Syslog4jAppender.java
@@ -4,9 +4,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.util.LevelToSyslogSeverity;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
-import org.productivity.java.syslog4j.SyslogConfigIF;
-import org.productivity.java.syslog4j.SyslogIF;
-import org.productivity.java.syslog4j.SyslogRuntimeException;
+import org.graylog2.syslog4j.SyslogConfigIF;
+import org.graylog2.syslog4j.SyslogIF;
+import org.graylog2.syslog4j.SyslogRuntimeException;
 
 public class Syslog4jAppender<E> extends AppenderBase<E> {
     SyslogIF syslog;

--- a/src/test/java/com/papertrailapp/logback/Syslog4jAppenderTest.java
+++ b/src/test/java/com/papertrailapp/logback/Syslog4jAppenderTest.java
@@ -6,11 +6,11 @@ import ch.qos.logback.core.joran.spi.JoranException;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.productivity.java.syslog4j.server.SyslogServer;
-import org.productivity.java.syslog4j.server.impl.event.printstream.PrintStreamSyslogServerEventHandler;
-import org.productivity.java.syslog4j.server.impl.net.tcp.TCPNetSyslogServerConfig;
-import org.productivity.java.syslog4j.server.impl.net.tcp.ssl.SSLTCPNetSyslogServerConfig;
-import org.productivity.java.syslog4j.server.impl.net.udp.UDPNetSyslogServerConfig;
+import org.graylog2.syslog4j.server.SyslogServer;
+import org.graylog2.syslog4j.server.impl.event.printstream.PrintStreamSyslogServerEventHandler;
+import org.graylog2.syslog4j.server.impl.net.tcp.TCPNetSyslogServerConfig;
+import org.graylog2.syslog4j.server.impl.net.tcp.ssl.SSLTCPNetSyslogServerConfig;
+import org.graylog2.syslog4j.server.impl.net.udp.UDPNetSyslogServerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/resources/logback-syslog4j-tcp.xml
+++ b/src/test/resources/logback-syslog4j-tcp.xml
@@ -4,7 +4,7 @@
       <pattern>%date %-5level %logger{35} - %message%n</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
       <host>localhost</host>
       <port>45553</port>
       <ident>syslog-test</ident>

--- a/src/test/resources/logback-syslog4j-tls.xml
+++ b/src/test/resources/logback-syslog4j-tls.xml
@@ -4,7 +4,7 @@
       <pattern>%date %-5level %logger{35} - %message%n</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">
       <host>localhost</host>
       <port>45554</port>
       <ident>syslog-test</ident>

--- a/src/test/resources/logback-syslog4j-udp.xml
+++ b/src/test/resources/logback-syslog4j-udp.xml
@@ -4,7 +4,7 @@
       <pattern>%date %-5level %logger{35} - %message%n</pattern>
     </layout>
 
-    <syslogConfig class="org.productivity.java.syslog4j.impl.net.udp.UDPNetSyslogConfig">
+    <syslogConfig class="org.graylog2.syslog4j.impl.net.udp.UDPNetSyslogConfig">
       <host>localhost</host>
       <port>45553</port>
       <ident>syslog-test</ident>


### PR DESCRIPTION
The original syslog4j dependency used, has been produced in 2010. There are no newer versions available and the project seems to be unmaintained. The main problem is that the original dependency contains Java 5 specific bytecode, which has been deprecated. More specifically, a project that I am currently working has been dealing with a problem similar to the one discussed [here](https://issuetracker.google.com/issues/141497570?pli=1), where the culprit is the syslog4j dependency pull from here. 

The solution appears to be to use the newer fork of the syslog4j library, from [graylog2](https://github.com/graylog-labs/syslog4j-graylog2), which is mostly a drop-in replacement (it uses different package names).